### PR TITLE
fix: adds check for original content existence

### DIFF
--- a/src/Events/LivewireDispatcher.php
+++ b/src/Events/LivewireDispatcher.php
@@ -50,6 +50,10 @@ class LivewireDispatcher
             HTML)
         );
 
+        // Laravel dispatches the ResponseHandled event even for response
+        // objects that don't include the `original` property.
+        // The typehint in Laravel core is wrong, so we ignore
+        /* @phpstan-ignore function.alreadyNarrowedType */
         if (property_exists($handled->response, 'original')) {
             $handled->response->original = $originalContent;
         }


### PR DESCRIPTION
I was unable to build or run the application because the `$handled->response` object did not contain the `original` property.

I implemented a local fix that resolved the issue at the time. However, after several subsequent builds and runs, I haven’t been able to reproduce the problem — all `$handled->response` objects now correctly include the `original` property.

I’m not sure what initially caused the missing property, but this change ensures that similar build or runtime failures won’t occur in the future.