### PR TITLE
remove pnpm installer option

### DIFF
--- a/src/Drivers/Electron/Commands/InstallCommand.php
+++ b/src/Drivers/Electron/Commands/InstallCommand.php
@@ -25,7 +25,7 @@ class InstallCommand extends Command
     protected $signature = 'native:install
         {--force : Overwrite existing files by default}
         {--publish : Publish the Electron project to your project\'s root}
-        {--installer=npm : The package installer to use: npm, yarn or pnpm}';
+        {--installer=npm : The package installer to use: npm or yarn}';
 
     public function handle(): void
     {

--- a/src/Drivers/Electron/Traits/ExecuteCommand.php
+++ b/src/Drivers/Electron/Traits/ExecuteCommand.php
@@ -50,12 +50,10 @@ trait ExecuteCommand
             'install' => [
                 'npm' => 'npm install',
                 'yarn' => 'yarn',
-                'pnpm' => 'pnpm install',
             ],
             'dev' => [
                 'npm' => 'npm run dev',
                 'yarn' => 'yarn dev',
-                'pnpm' => 'pnpm run dev',
             ],
         ];
 


### PR DESCRIPTION
This PR removes support for the `pnpm` package manager. The changes ensure that only `npm` and `yarn` are available options for installing and running the Electron project.

Closes #29 
