### PR TITLE
fix(controller): 🐛 replace deprecated Request::get() with Request::input()

### DIFF
--- a/src/Http/Controllers/CreateSecurityCookieController.php
+++ b/src/Http/Controllers/CreateSecurityCookieController.php
@@ -8,7 +8,7 @@ class CreateSecurityCookieController
 {
     public function __invoke(Request $request)
     {
-        abort_if($request->get('secret') !== config('native-php.secret'), 403);
+        abort_if($request->input('secret') !== config('native-php.secret'), 403);
 
         return redirect('/')->cookie(cookie(
             name: '_php_native',

--- a/src/Http/Controllers/DispatchEventFromAppController.php
+++ b/src/Http/Controllers/DispatchEventFromAppController.php
@@ -8,8 +8,8 @@ class DispatchEventFromAppController
 {
     public function __invoke(Request $request)
     {
-        $event = $request->get('event');
-        $payload = $request->get('payload', []);
+        $event = $request->input('event');
+        $payload = $request->input('payload', []);
 
         if (class_exists($event)) {
             $event = new $event(...$payload);


### PR DESCRIPTION
This pull request replaces usages of the deprecated `Request::get()` method with `Request::input()` in `CreateSecurityCookieController` and `DispatchEventFromAppController`.

The `Request::get()` method has been deprecated in Symfony 7.4 (underlying Laravel's Request class) and will be removed in Symfony 8.0. Switching to `input()` resolves the deprecation warnings and aligns with Laravel best practices for retrieving input data.

References:
- https://symfony.com/blog/new-in-symfony-7-4-request-class-improvements
- https://github.com/laravel/framework/issues/57962
- https://laravel.com/docs/12.x/requests#retrieving-an-input-value
- https://laravel.com/docs/11.x/requests#retrieving-an-input-value

**Changes:**

*   **`CreateSecurityCookieController`**: Replaced `$request->get('secret')` with `$request->input('secret')`.
*   **`DispatchEventFromAppController`**: Replaced `$request->get('event')` and `$request->get('payload')` with `$request->input(...)`.

closes #59