### PR TITLE
Remove publisherName from azureSignOptions (TrustedSigning v0.4.1 compat)

### DIFF
--- a/resources/electron/electron-builder.mjs
+++ b/resources/electron/electron-builder.mjs
@@ -13,7 +13,6 @@ const deepLinkProtocol = process.env.NATIVEPHP_DEEPLINK_SCHEME;
 const updaterEnabled = process.env.NATIVEPHP_UPDATER_ENABLED === 'true';
 
 // Azure signing configuration
-const azurePublisherName = process.env.NATIVEPHP_AZURE_PUBLISHER_NAME;
 const azureEndpoint = process.env.NATIVEPHP_AZURE_ENDPOINT;
 const azureCertificateProfileName = process.env.NATIVEPHP_AZURE_CERTIFICATE_PROFILE_NAME;
 const azureCodeSigningAccountName = process.env.NATIVEPHP_AZURE_CODE_SIGNING_ACCOUNT_NAME;
@@ -83,9 +82,8 @@ export default {
     afterSign: 'build/notarize.js',
     win: {
         executableName: fileName,
-        ...(azurePublisherName && azureEndpoint && azureCertificateProfileName && azureCodeSigningAccountName ? {
+        ...(azureEndpoint && azureCertificateProfileName && azureCodeSigningAccountName ? {
             azureSignOptions: {
-                publisherName: azurePublisherName,
                 endpoint: azureEndpoint,
                 certificateProfileName: azureCertificateProfileName,
                 codeSigningAccountName: azureCodeSigningAccountName


### PR DESCRIPTION
## Summary

- Removes `publisherName` from `azureSignOptions` in `electron-builder.mjs` to fix Windows code signing failures with `TrustedSigning` PowerShell module v0.4.1+.
- Removes the now-unused `azurePublisherName` variable and simplifies the guard condition accordingly.

## Problem

electron-builder delegates Windows Azure Trusted Signing to the `Invoke-TrustedSigning` PowerShell cmdlet (from the `TrustedSigning` module). In version 0.4.1 of that module, the `-publisherName` parameter was removed. Because NativePHP's config still passes `publisherName` in `azureSignOptions`, electron-builder forwards it as `-publisherName` to the cmdlet, which then fails with:

```
A parameter cannot be found that matches parameter name 'publisherName'.
```

You can verify the parameter was removed by comparing the [TrustedSigning module v0.4.0](https://www.powershellgallery.com/packages/TrustedSigning/0.4.0) and [v0.4.1](https://www.powershellgallery.com/packages/TrustedSigning/0.4.1) releases, or by inspecting [electron-builder's `windowsSignAzureManager.js`](https://github.com/nicedoc/electron-builder/blob/main/packages/app-builder-lib/src/codeSign/windowsSignAzureManager.ts#L22) which pins the install to `TrustedSigning@0.4.1`.

## Fix

Remove the `publisherName` property from the `azureSignOptions` object, the `azurePublisherName` variable that fed it, and the `azurePublisherName &&` check from the guard condition (since we no longer need that env var to be set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)