### PR TITLE
Make deleteAppDataOnUninstall configurable

### DIFF
--- a/config/nativephp.php
+++ b/config/nativephp.php
@@ -171,6 +171,15 @@ return [
     ],
 
     /**
+     * The NSIS installer configuration for Windows builds.
+     *
+     * @see https://www.electron.build/generated/nsisoptions
+     */
+    'nsis' => [
+        'delete_app_data_on_uninstall' => env('NATIVEPHP_NSIS_DELETE_APP_DATA', false),
+    ],
+
+    /**
      * Custom PHP binary path.
      */
     'binary_path' => env('NATIVEPHP_PHP_BINARY_PATH', null),

--- a/resources/electron/electron-builder.mjs
+++ b/resources/electron/electron-builder.mjs
@@ -11,6 +11,7 @@ const appVersion = process.env.NATIVEPHP_APP_VERSION;
 const appCopyright = process.env.NATIVEPHP_APP_COPYRIGHT;
 const deepLinkProtocol = process.env.NATIVEPHP_DEEPLINK_SCHEME;
 const updaterEnabled = process.env.NATIVEPHP_UPDATER_ENABLED === 'true';
+const deleteAppDataOnUninstall = process.env.NATIVEPHP_NSIS_DELETE_APP_DATA === 'true';
 
 // Azure signing configuration
 const azureEndpoint = process.env.NATIVEPHP_AZURE_ENDPOINT;
@@ -95,6 +96,7 @@ export default {
         shortcutName: '${productName}',
         uninstallDisplayName: '${productName}',
         createDesktopShortcut: 'always',
+        deleteAppDataOnUninstall: deleteAppDataOnUninstall,
     },
     protocols: {
         name: deepLinkProtocol,

--- a/src/Drivers/Electron/Commands/BuildCommand.php
+++ b/src/Drivers/Electron/Commands/BuildCommand.php
@@ -142,6 +142,7 @@ class BuildCommand extends Command
                 'NATIVEPHP_APP_FILENAME' => Str::slug(config('app.name')),
                 'NATIVEPHP_APP_AUTHOR' => config('nativephp.author'),
                 'NATIVEPHP_UPDATER_CONFIG' => json_encode(Updater::builderOptions()),
+                'NATIVEPHP_NSIS_DELETE_APP_DATA' => config('nativephp.nsis.delete_app_data_on_uninstall') ? 'true' : 'false',
                 'NATIVEPHP_DEEPLINK_SCHEME' => config('nativephp.deeplink_scheme'),
                 // Notarization
                 'NATIVEPHP_APPLE_ID' => config('nativephp-internal.notarization.apple_id'),

--- a/tests/Build/BuildCommandEnvironmentVariablesTest.php
+++ b/tests/Build/BuildCommandEnvironmentVariablesTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Support\Facades\Config;
+use Native\Desktop\Drivers\Electron\Commands\BuildCommand;
+
+it('passes NSIS delete app data flag as true when config is enabled', function () {
+    Config::set('nativephp.nsis.delete_app_data_on_uninstall', true);
+
+    $command = app(BuildCommand::class);
+    $envVars = (new ReflectionMethod($command, 'getEnvironmentVariables'))->invoke($command);
+
+    expect($envVars['NATIVEPHP_NSIS_DELETE_APP_DATA'])->toBe('true');
+});
+
+it('passes NSIS delete app data flag as false when config is disabled', function () {
+    Config::set('nativephp.nsis.delete_app_data_on_uninstall', false);
+
+    $command = app(BuildCommand::class);
+    $envVars = (new ReflectionMethod($command, 'getEnvironmentVariables'))->invoke($command);
+
+    expect($envVars['NATIVEPHP_NSIS_DELETE_APP_DATA'])->toBe('false');
+});
+
+it('defaults NSIS delete app data flag to false when config is not set', function () {
+    Config::set('nativephp.nsis.delete_app_data_on_uninstall', null);
+
+    $command = app(BuildCommand::class);
+    $envVars = (new ReflectionMethod($command, 'getEnvironmentVariables'))->invoke($command);
+
+    expect($envVars['NATIVEPHP_NSIS_DELETE_APP_DATA'])->toBe('false');
+});


### PR DESCRIPTION
## Summary
- Add a `nsis.delete_app_data_on_uninstall` config option (defaults to `false`) so app developers can opt in to deleting `%APPDATA%\{appName}` on Windows uninstall
- The option is passed from `config/nativephp.php` → `BuildCommand` env var → `electron-builder.mjs`

The underlying NSIS template already skips deletion during updates (`${ifNot} ${isUpdated}`), so app data is preserved when updating to a new version.

### Usage

In your app's `config/nativephp.php`:
```php
'nsis' => [
    'delete_app_data_on_uninstall' => true,
],
```

Or via environment variable: `NATIVEPHP_NSIS_DELETE_APP_DATA=true`

## Test plan
- [ ] Build a Windows NSIS installer with the option set to `true`
- [ ] Install the app and verify app data is created in `%APPDATA%`
- [ ] Uninstall the app and verify `%APPDATA%\{appName}` is deleted
- [ ] Build with the option set to `false` (default) and verify app data persists after uninstall
- [ ] Update the app (install over existing) and verify app data is preserved in both cases