### PR TITLE
Disable autoInstallOnAppQuit to prevent silent background installs on Windows

### DIFF
--- a/resources/electron/electron-plugin/src/index.ts
+++ b/resources/electron/electron-plugin/src/index.ts
@@ -226,6 +226,7 @@ class NativePHP {
         });
       }
 
+      autoUpdater.autoInstallOnAppQuit = false;
       autoUpdater.checkForUpdatesAndNotify();
     }
   }


### PR DESCRIPTION
## Summary
- Set `autoUpdater.autoInstallOnAppQuit = false` in `startAutoUpdater()`
- On Windows, silent NSIS installs race with the user relaunching the app, causing the app to get stuck on the loading screen
- Developers retain full control via the `UpdateDownloaded` event and `quitAndInstall()` API

Fixes #90

## Context
When `autoInstallOnAppQuit` is `true` (the electron-updater default), the NSIS installer runs silently on quit with no visible UI. NativePHP Windows installations can take several minutes (around 3 minutes in our case) due to the size of the bundled PHP runtime and app resources. Since the user sees no feedback, they will almost certainly relaunch the app while the installer is still replacing files on disk — corrupting the running instance.

Setting this to `false` is safe: the update is still downloaded in the background and the `UpdateDownloaded` event still fires. The developer can prompt the user and call `quitAndInstall()` when appropriate.

## Test plan
- [ ] Publish update, close app, relaunch immediately — app works (no silent install racing)
- [ ] `UpdateDownloaded` event still fires and `quitAndInstall()` still works