### PR TITLE
fix: github updater provider with private repositories

### DIFF
--- a/src/Drivers/Electron/Updater/GitHubProvider.php
+++ b/src/Drivers/Electron/Updater/GitHubProvider.php
@@ -11,6 +11,7 @@ class GitHubProvider implements Updater
     public function environmentVariables(): array
     {
         return [
+            'GH_TOKEN' => $this->config['autoupdate_token'],
             'GITHUB_RELEASE_TOKEN' => $this->config['token'],
         ];
     }

--- a/src/Drivers/Electron/Updater/GitHubProvider.php
+++ b/src/Drivers/Electron/Updater/GitHubProvider.php
@@ -11,7 +11,7 @@ class GitHubProvider implements Updater
     public function environmentVariables(): array
     {
         return [
-            'GH_TOKEN' => $this->config['token'],
+            'GITHUB_RELEASE_TOKEN' => $this->config['token'],
         ];
     }
 


### PR DESCRIPTION
Using `GITHUB_RELEASE_TOKEN` instead of `GH_TOKEN` enable the possibility to publish to a private repository, 

See references in `electron-build` [documentation](https://www.electron.build/publish) and [code](https://github.com/electron-userland/electron-builder/blob/master/packages/electron-publish/src/gitHubPublisher.ts#L52).

~~At the moment the `app-update.yml` file in the electron builder does not receive any token, which is fine for checking for updates from a public repository, but not from a private one where a token is required instead.~~
