### PR TITLE
feat: Add native splash screen support via Electron

### DIFF
--- a/resources/electron/src/main/index.js
+++ b/resources/electron/src/main/index.js
@@ -1,6 +1,7 @@
 import NativePHP from '#plugin';
 import { app } from 'electron';
 import path from 'path';
+import { createSplash } from './splash.js';
 
 // Inherit User's PATH in Process & ChildProcess
 import fixPath from 'fix-path';
@@ -14,7 +15,20 @@ const executable = process.platform === 'win32' ? 'php.exe' : 'php';
 const phpBinary = path.join(buildPath, 'php', executable);
 const appPath = path.join(buildPath, 'app');
 
-/**
- * Turn on the lights for the NativePHP app.
- */
-NativePHP.bootstrap(app, defaultIcon, phpBinary, certificate, appPath);
+let splashWindow;
+
+app.whenReady().then(() => {
+    splashWindow = createSplash(import.meta.dirname);
+
+    /**
+     * Turn on the lights for the NativePHP app.
+     */
+    NativePHP.bootstrap(app, defaultIcon, phpBinary, certificate, appPath);
+});
+
+app.on('browser-window-created', (event, window) => {
+    if (splashWindow && window !== splashWindow) {
+        splashWindow.close();
+        splashWindow = null;
+    }
+});

--- a/resources/electron/src/main/index.js
+++ b/resources/electron/src/main/index.js
@@ -1,8 +1,7 @@
 import NativePHP from '#plugin';
-import { app } from 'electron';
+import { app, BrowserWindow } from 'electron';
 import path from 'path';
 import { createSplash } from './splash.js';
-
 // Inherit User's PATH in Process & ChildProcess
 import fixPath from 'fix-path';
 fixPath();
@@ -18,17 +17,24 @@ const appPath = path.join(buildPath, 'app');
 let splashWindow;
 
 app.whenReady().then(() => {
-    splashWindow = createSplash(import.meta.dirname);
+    try {
+        splashWindow = createSplash(appPath, import.meta.dirname);
+    } catch (error) {
+        console.error('Error creating splash screen:', error);
+    }
 
-    /**
-     * Turn on the lights for the NativePHP app.
-     */
     NativePHP.bootstrap(app, defaultIcon, phpBinary, certificate, appPath);
 });
 
 app.on('browser-window-created', (event, window) => {
     if (splashWindow && window !== splashWindow) {
-        splashWindow.close();
-        splashWindow = null;
+        window.webContents.on('did-navigate', (evt, url) => {
+            if (url.startsWith('http://127.0.0.1') || url.startsWith('http://localhost')) {
+                if (splashWindow) {
+                    splashWindow.close();
+                    splashWindow = null;
+                }
+            }
+        });
     }
 });

--- a/resources/electron/src/main/index.js
+++ b/resources/electron/src/main/index.js
@@ -1,7 +1,8 @@
 import NativePHP from '#plugin';
-import { app, BrowserWindow } from 'electron';
+import { app } from 'electron';
 import path from 'path';
 import { createSplash } from './splash.js';
+
 // Inherit User's PATH in Process & ChildProcess
 import fixPath from 'fix-path';
 fixPath();
@@ -17,24 +18,17 @@ const appPath = path.join(buildPath, 'app');
 let splashWindow;
 
 app.whenReady().then(() => {
-    try {
-        splashWindow = createSplash(appPath, import.meta.dirname);
-    } catch (error) {
-        console.error('Error creating splash screen:', error);
-    }
+    splashWindow = createSplash(import.meta.dirname);
 
+    /**
+     * Turn on the lights for the NativePHP app.
+     */
     NativePHP.bootstrap(app, defaultIcon, phpBinary, certificate, appPath);
 });
 
 app.on('browser-window-created', (event, window) => {
     if (splashWindow && window !== splashWindow) {
-        window.webContents.on('did-navigate', (evt, url) => {
-            if (url.startsWith('http://127.0.0.1') || url.startsWith('http://localhost')) {
-                if (splashWindow) {
-                    splashWindow.close();
-                    splashWindow = null;
-                }
-            }
-        });
+        splashWindow.close();
+        splashWindow = null;
     }
 });

--- a/resources/electron/src/main/splash.js
+++ b/resources/electron/src/main/splash.js
@@ -1,9 +1,13 @@
 import path from 'path';
 import fs from 'fs';
-import { BrowserWindow } from 'electron';
+import { BrowserWindow, app } from 'electron';
 
-function getProjectRoot(startPath) {
-    let currentPath = startPath;
+function getLaravelBaseDir(appPath, importMetaDirname) {
+    if (app.isPackaged) {
+        return appPath;
+    }
+
+    let currentPath = importMetaDirname;
     for (let i = 0; i < 10; i++) {
         if (fs.existsSync(path.join(currentPath, '.env'))) {
             return currentPath;
@@ -12,45 +16,39 @@ function getProjectRoot(startPath) {
         if (parentPath === currentPath) break;
         currentPath = parentPath;
     }
-    return null;
+    return process.cwd();
 }
 
-export function getEnvConfig(projectRoot, key, defaultValue = null) {
-    if (!projectRoot) return defaultValue;
-    const envPath = path.join(projectRoot, '.env');
+export function getEnvConfig(baseDir, key, defaultValue = null) {
+    if (!baseDir) return defaultValue;
+    const envPath = path.join(baseDir, '.env');
 
     try {
-        const content = fs.readFileSync(envPath, 'utf8');
-        const lines = content.split('\n');
-        for (const line of lines) {
-            const trimmed = line.trim();
-            if (!trimmed || trimmed.startsWith('#')) continue;
-            const [lineKey, ...valueParts] = trimmed.split('=');
-            if (lineKey.trim() === key) {
-                return valueParts.join('=').trim().replace(/^["']|["']$/g, '');
+        if (fs.existsSync(envPath)) {
+            const content = fs.readFileSync(envPath, 'utf8');
+            const lines = content.split('\n');
+            for (const line of lines) {
+                const trimmed = line.trim();
+                if (!trimmed || trimmed.startsWith('#')) continue;
+                const [lineKey, ...valueParts] = trimmed.split('=');
+                if (lineKey.trim() === key) {
+                    return valueParts.join('=').trim().replace(/^["']|["']$/g, '');
+                }
             }
         }
-    } catch (e) { }
+    } catch (e) { /* ignore */ }
     return defaultValue;
 }
 
-export function createSplash(importMetaDirname) {
-    const projectRoot = getProjectRoot(importMetaDirname);
+export function createSplash(appPath, importMetaDirname) {
+    const baseDir = getLaravelBaseDir(appPath, importMetaDirname);
 
-    if (!projectRoot) return null;
-
-    const enabled = getEnvConfig(projectRoot, 'NATIVEPHP_SPLASH_ENABLED', 'false') === 'true';
+    const enabled = getEnvConfig(baseDir, 'NATIVEPHP_SPLASH_ENABLED', 'false') === 'true';
     if (!enabled) return null;
 
-    const width = parseInt(getEnvConfig(projectRoot, 'NATIVEPHP_SPLASH_WIDTH', '400'));
-    const height = parseInt(getEnvConfig(projectRoot, 'NATIVEPHP_SPLASH_HEIGHT', '300'));
-    const splashRelativePath = getEnvConfig(projectRoot, 'NATIVEPHP_SPLASH_HTML', 'public/splash.html');
-
-    const finalHtmlPath = path.join(projectRoot, splashRelativePath);
-
-    if (!fs.existsSync(finalHtmlPath)) {
-        return null;
-    }
+    const width = parseInt(getEnvConfig(baseDir, 'NATIVEPHP_SPLASH_WIDTH', '400'));
+    const height = parseInt(getEnvConfig(baseDir, 'NATIVEPHP_SPLASH_HEIGHT', '300'));
+    const splashRelativePath = getEnvConfig(baseDir, 'NATIVEPHP_SPLASH_HTML', 'public/splash.html');
 
     const splash = new BrowserWindow({
         width,
@@ -61,6 +59,13 @@ export function createSplash(importMetaDirname) {
         webPreferences: { nodeIntegration: false }
     });
 
-    splash.loadFile(finalHtmlPath);
+    const finalHtmlPath = path.join(baseDir, splashRelativePath);
+
+    if (fs.existsSync(finalHtmlPath)) {
+        splash.loadURL('file:///' + finalHtmlPath.replace(/\\/g, '/'));
+    } else {
+        console.error(`[NativePHP Splash] HTML Not Found. Path: ${finalHtmlPath}`);
+    }
+
     return splash;
 }

--- a/resources/electron/src/main/splash.js
+++ b/resources/electron/src/main/splash.js
@@ -1,0 +1,66 @@
+import path from 'path';
+import fs from 'fs';
+import { BrowserWindow } from 'electron';
+
+function getProjectRoot(startPath) {
+    let currentPath = startPath;
+    for (let i = 0; i < 10; i++) {
+        if (fs.existsSync(path.join(currentPath, '.env'))) {
+            return currentPath;
+        }
+        const parentPath = path.join(currentPath, '..');
+        if (parentPath === currentPath) break;
+        currentPath = parentPath;
+    }
+    return null;
+}
+
+export function getEnvConfig(projectRoot, key, defaultValue = null) {
+    if (!projectRoot) return defaultValue;
+    const envPath = path.join(projectRoot, '.env');
+
+    try {
+        const content = fs.readFileSync(envPath, 'utf8');
+        const lines = content.split('\n');
+        for (const line of lines) {
+            const trimmed = line.trim();
+            if (!trimmed || trimmed.startsWith('#')) continue;
+            const [lineKey, ...valueParts] = trimmed.split('=');
+            if (lineKey.trim() === key) {
+                return valueParts.join('=').trim().replace(/^["']|["']$/g, '');
+            }
+        }
+    } catch (e) { }
+    return defaultValue;
+}
+
+export function createSplash(importMetaDirname) {
+    const projectRoot = getProjectRoot(importMetaDirname);
+
+    if (!projectRoot) return null;
+
+    const enabled = getEnvConfig(projectRoot, 'NATIVEPHP_SPLASH_ENABLED', 'false') === 'true';
+    if (!enabled) return null;
+
+    const width = parseInt(getEnvConfig(projectRoot, 'NATIVEPHP_SPLASH_WIDTH', '400'));
+    const height = parseInt(getEnvConfig(projectRoot, 'NATIVEPHP_SPLASH_HEIGHT', '300'));
+    const splashRelativePath = getEnvConfig(projectRoot, 'NATIVEPHP_SPLASH_HTML', 'public/splash.html');
+
+    const finalHtmlPath = path.join(projectRoot, splashRelativePath);
+
+    if (!fs.existsSync(finalHtmlPath)) {
+        return null;
+    }
+
+    const splash = new BrowserWindow({
+        width,
+        height,
+        frame: false,
+        transparent: true,
+        alwaysOnTop: true,
+        webPreferences: { nodeIntegration: false }
+    });
+
+    splash.loadFile(finalHtmlPath);
+    return splash;
+}

--- a/resources/electron/src/main/splash.js
+++ b/resources/electron/src/main/splash.js
@@ -1,13 +1,9 @@
 import path from 'path';
 import fs from 'fs';
-import { BrowserWindow, app } from 'electron';
+import { BrowserWindow } from 'electron';
 
-function getLaravelBaseDir(appPath, importMetaDirname) {
-    if (app.isPackaged) {
-        return appPath;
-    }
-
-    let currentPath = importMetaDirname;
+function getProjectRoot(startPath) {
+    let currentPath = startPath;
     for (let i = 0; i < 10; i++) {
         if (fs.existsSync(path.join(currentPath, '.env'))) {
             return currentPath;
@@ -16,39 +12,45 @@ function getLaravelBaseDir(appPath, importMetaDirname) {
         if (parentPath === currentPath) break;
         currentPath = parentPath;
     }
-    return process.cwd();
+    return null;
 }
 
-export function getEnvConfig(baseDir, key, defaultValue = null) {
-    if (!baseDir) return defaultValue;
-    const envPath = path.join(baseDir, '.env');
+export function getEnvConfig(projectRoot, key, defaultValue = null) {
+    if (!projectRoot) return defaultValue;
+    const envPath = path.join(projectRoot, '.env');
 
     try {
-        if (fs.existsSync(envPath)) {
-            const content = fs.readFileSync(envPath, 'utf8');
-            const lines = content.split('\n');
-            for (const line of lines) {
-                const trimmed = line.trim();
-                if (!trimmed || trimmed.startsWith('#')) continue;
-                const [lineKey, ...valueParts] = trimmed.split('=');
-                if (lineKey.trim() === key) {
-                    return valueParts.join('=').trim().replace(/^["']|["']$/g, '');
-                }
+        const content = fs.readFileSync(envPath, 'utf8');
+        const lines = content.split('\n');
+        for (const line of lines) {
+            const trimmed = line.trim();
+            if (!trimmed || trimmed.startsWith('#')) continue;
+            const [lineKey, ...valueParts] = trimmed.split('=');
+            if (lineKey.trim() === key) {
+                return valueParts.join('=').trim().replace(/^["']|["']$/g, '');
             }
         }
-    } catch (e) { /* ignore */ }
+    } catch (e) { }
     return defaultValue;
 }
 
-export function createSplash(appPath, importMetaDirname) {
-    const baseDir = getLaravelBaseDir(appPath, importMetaDirname);
+export function createSplash(importMetaDirname) {
+    const projectRoot = getProjectRoot(importMetaDirname);
 
-    const enabled = getEnvConfig(baseDir, 'NATIVEPHP_SPLASH_ENABLED', 'false') === 'true';
+    if (!projectRoot) return null;
+
+    const enabled = getEnvConfig(projectRoot, 'NATIVEPHP_SPLASH_ENABLED', 'false') === 'true';
     if (!enabled) return null;
 
-    const width = parseInt(getEnvConfig(baseDir, 'NATIVEPHP_SPLASH_WIDTH', '400'));
-    const height = parseInt(getEnvConfig(baseDir, 'NATIVEPHP_SPLASH_HEIGHT', '300'));
-    const splashRelativePath = getEnvConfig(baseDir, 'NATIVEPHP_SPLASH_HTML', 'public/splash.html');
+    const width = parseInt(getEnvConfig(projectRoot, 'NATIVEPHP_SPLASH_WIDTH', '400'));
+    const height = parseInt(getEnvConfig(projectRoot, 'NATIVEPHP_SPLASH_HEIGHT', '300'));
+    const splashRelativePath = getEnvConfig(projectRoot, 'NATIVEPHP_SPLASH_HTML', 'public/splash.html');
+
+    const finalHtmlPath = path.join(projectRoot, splashRelativePath);
+
+    if (!fs.existsSync(finalHtmlPath)) {
+        return null;
+    }
 
     const splash = new BrowserWindow({
         width,
@@ -59,13 +61,6 @@ export function createSplash(appPath, importMetaDirname) {
         webPreferences: { nodeIntegration: false }
     });
 
-    const finalHtmlPath = path.join(baseDir, splashRelativePath);
-
-    if (fs.existsSync(finalHtmlPath)) {
-        splash.loadURL('file:///' + finalHtmlPath.replace(/\\/g, '/'));
-    } else {
-        console.error(`[NativePHP Splash] HTML Not Found. Path: ${finalHtmlPath}`);
-    }
-
+    splash.loadFile(finalHtmlPath);
     return splash;
 }


### PR DESCRIPTION
## 🚀 The Problem
Currently, there is a significant "dead zone" (especially on Windows) between launching the application `.exe` and the first window appearing. This is because NativePHP must first initialize the PHP binary, start the local server, and boot the Laravel framework before any window can be opened via the `NativeAppServiceProvider`.

On some systems, this leads to several seconds of "silence" where the user might think the application didn't start.

## ✨ The Solution
This PR introduces a **native Electron splash screen** that triggers immediately after the Electron process starts, providing instant visual feedback. 

Since it runs in the Electron main process, it doesn't wait for PHP to be ready. It includes a robust `.env` parser that works in both development (vendor context) and production environments.

## 🛠 Key Features
- **Instant Feedback:** Shows a window within milliseconds of the double-click.
- **Smart Env Discovery:** A recursive "Find-Up" algorithm to locate the `.env` file regardless of the directory depth (Dev vs. Prod).
- **Fully Configurable:** Options for dimensions, custom HTML, and a master toggle.
- **Auto-Cleanup:** The splash screen automatically closes as soon as the first application window is created by the PHP side.

## ⚙️ Configuration
Users can customize the behavior by adding these keys to their `.env` file:

```bash
NATIVEPHP_SPLASH_ENABLED=true
NATIVEPHP_SPLASH_WIDTH=400
NATIVEPHP_SPLASH_HEIGHT=300
NATIVEPHP_SPLASH_HTML=public/splash.html

```

## 📂 Implementation Details

### `splash.js`

A new module responsible for:

* Finding the project root and parsing the `.env`.
* Creating a frameless, transparent `BrowserWindow`.

### `index.js`

Modified the Electron entry point to:

* Import and trigger the splash screen during `app.whenReady()`.
* Listen for the `browser-window-created` event to dismiss the splash screen once the Laravel app is ready.

## ✅ Checklist

* [x] Tested in Development mode (`native:serve`)
* [x] Tested in Production build (`native:build`)
* [x] Verified `.env` parsing logic on Windows
* [x] Ensured no breaking changes for users without splash configuration (defaults to `false`)
