### PR TITLE
Allow Symfony 8 components for Laravel 13 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,8 +42,7 @@
         "laravel/prompts": "^0.1.1|^0.2|^0.3",
         "nativephp/php-bin": "^1.0",
         "spatie/laravel-package-tools": "^1.16.4",
-        "symfony/filesystem": "^6.4|^7.2",
-        "symfony/finder": "^6.2|^7.0",
+        "symfony/filesystem": "^6.4|^7.2|^8.0",
         "ext-zip": "*"
     },
     "require-dev": {


### PR DESCRIPTION
On a fresh Laravel 13 app, `composer require nativephp/desktop` fails because Laravel 13 locks `symfony/finder` at `v8.x`, but this package caps it at `^7.0`:

```
- nativephp/desktop 2.2.0 requires symfony/finder ^6.2|^7.0 -> found symfony/finder[v6.2.0, ..., v7.4.8] but the package is fixed to v8.0.8 (lock file version) by a partial update and that version does not match.
```

- Drop `symfony/finder` from `require` — it has no imports in `src/` or `tests/`. `laravel/framework` pulls it in transitively, so the framework's own constraint will pick the right version per Laravel release.
- Widen `symfony/filesystem` to `^6.4|^7.2|^8.0` (additive — older Laravel versions still resolve to Sf 6/7). This one is genuinely used (`mirror`, `exists`, `remove`, `mkdir`, `copy`, `dumpFile`, `Path::join`) and the methods are stable in Symfony 8.