### PR TITLE
prune only the php binary archives, not the whole bin dir

### DIFF
--- a/src/Builder/Concerns/PrunesVendorDirectory.php
+++ b/src/Builder/Concerns/PrunesVendorDirectory.php
@@ -24,10 +24,14 @@ trait PrunesVendorDirectory
             $this->buildPath('app/vendor/nativephp/php-bin'),
         ]);
 
-        // Remove custom php binary package directory
-        $binaryPackageDirectory = trim($this->binaryPackageDirectory(), "./\\ \t\n\r\0\x0B");
-        if ($binaryPackageDirectory !== '' && $filesystem->exists($this->buildPath("app/{$binaryPackageDirectory}"))) {
-            $filesystem->remove($this->buildPath("app/{$binaryPackageDirectory}"));
-        }
+        // Remove the bundled PHP binaries for a custom binary path.
+        // They get duplicated into the app's build resources, so
+        // the copies left in the source tree are dead weight.
+        //
+        // We remove only the archives we manage, never the
+        // parent directory, so the user's files are kept,
+        // and a root path never wipes the app (#115).
+        $binaryDirectory = $this->buildPath('app/'.$this->binaryPackageDirectory().'bin');
+        $filesystem->remove(glob("{$binaryDirectory}/*/*/php-*.zip"));
     }
 }

--- a/tests/Build/PruneVendorDirectoryTest.php
+++ b/tests/Build/PruneVendorDirectoryTest.php
@@ -20,6 +20,8 @@ beforeEach(function () use ($buildPath) {
 });
 
 afterEach(function () use ($buildPath) {
+    putenv('NATIVEPHP_PHP_BINARY_PATH');
+
     $filesystem = new Filesystem;
     $filesystem->remove($buildPath);
 });
@@ -54,30 +56,46 @@ $command = new class($buildPath)
 | Tests
 |--------------------------------------------------------------------------
 */
-it('removes the custom php binary package directory', function () use ($buildPath, $command) {
+it('prunes the bundled php binary archives from a custom binary directory', function () use ($buildPath, $command) {
     putenv('NATIVEPHP_PHP_BINARY_PATH=php-bin/');
 
     createFiles([
         "$buildPath/app/index.php",
-        "$buildPath/app/php-bin/bin/php",
+        "$buildPath/app/php-bin/bin/win/x64/php-8.4.zip",
+        "$buildPath/app/php-bin/bin/mac/arm64/php-8.4.zip",
     ]);
 
     $command->pruneVendorDirectory();
 
-    expect("$buildPath/app/php-bin")->not->toBeDirectory();
-    expect("$buildPath/app/index.php")->toBeFile();
-})->after(fn () => putenv('NATIVEPHP_PHP_BINARY_PATH'));
+    // The redundant archives are stripped...
+    expect("$buildPath/app/php-bin/bin/win/x64/php-8.4.zip")->not->toBeFile();
+    expect("$buildPath/app/php-bin/bin/mac/arm64/php-8.4.zip")->not->toBeFile();
 
-it('does not delete the app when the binary path normalizes to the app root', function () use ($buildPath, $command) {
+    // ...while the rest of the app is left intact.
+    expect("$buildPath/app/index.php")->toBeFile();
+});
+
+it('does not delete the app when the binary path is the project root', function () use ($buildPath, $command) {
+    // Regression test for #115: a binary path that normalises to the app root
+    // (e.g. binaries kept directly in the project's bin/ directory) must not
+    // take the whole app down with the prune.
     putenv('NATIVEPHP_PHP_BINARY_PATH=./');
 
     createFiles([
         "$buildPath/app/index.php",
-        "$buildPath/app/bin/win/x64/php.exe",
+        "$buildPath/app/bin/win/x64/php-8.4.zip",
+        "$buildPath/app/bin/mac/arm64/php-8.4.zip",
+        // Unrelated tooling a user happens to keep in bin/ must survive.
+        "$buildPath/app/bin/deploy.sh",
     ]);
 
     $command->pruneVendorDirectory();
 
+    // The app and any non-NativePHP files in bin/ are preserved...
     expect("$buildPath/app/index.php")->toBeFile();
-    expect("$buildPath/app/bin/win/x64/php.exe")->toBeFile();
-})->after(fn () => putenv('NATIVEPHP_PHP_BINARY_PATH'));
+    expect("$buildPath/app/bin/deploy.sh")->toBeFile();
+
+    // ...but the bundled php archives are still pruned.
+    expect("$buildPath/app/bin/win/x64/php-8.4.zip")->not->toBeFile();
+    expect("$buildPath/app/bin/mac/arm64/php-8.4.zip")->not->toBeFile();
+});


### PR DESCRIPTION
A small follow-up to #117. That stopped the app from being deleted, but as @bmckay959 spotted the binaries were still ending up in the bundle (his build went from 127MB to 212MB).

php.js extracts the one binary we need into the app's `build/php` resources during the build, so the `php-*.zip` files left in the copied source tree are redundant. The previous approach removed the whole binary directory to clear them, which had two problems: on a root path (`NATIVEPHP_PHP_BINARY_PATH=./`) there's nothing to remove without taking the app with it, so it skipped and left every archive behind; and elsewhere it could delete files a user keeps alongside the binaries.

This targets only the archives we manage, at their fixed `bin/{os}/{arch}/php-*.zip` location, never the containing directory. The build stays small, unrelated files in `bin/` survive, and the path collapse is gone since `app/./bin` normalises to `app/bin` rather than the app root.

Reworked the two tests to assert the archives are pruned while the app (and an unrelated `bin/` file) survive, instead of asserting the binaries are kept. Checked against the default, a custom subdir, and the root `./` path. 

Full suite passes, Pint and PHPStan clean.
