### PR TITLE
feat(print): add ability to print pdf on Windows

### DIFF
--- a/resources/electron/electron-plugin/dist/server/api/system.js
+++ b/resources/electron/electron-plugin/dist/server/api/system.js
@@ -9,6 +9,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 import { BrowserWindow, nativeTheme, safeStorage, systemPreferences } from 'electron';
 import express from 'express';
+import { readFileSync } from 'node:fs';
+import { parsePdfPageSizePoints, buildNativePrintOptions } from '../pdfPageSize.js';
 const router = express.Router();
 router.get('/can-prompt-touch-id', (req, res) => {
     res.json({
@@ -88,6 +90,76 @@ router.post('/print', (req, res) => __awaiter(void 0, void 0, void 0, function* 
         });
     });
     yield printWindow.loadURL(`data:text/html;charset=UTF-8,${html}`);
+}));
+router.post('/print-file', (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    const { path: filePath, printer, settings } = req.body;
+    let pagePoints = null;
+    try {
+        pagePoints = parsePdfPageSizePoints(readFileSync(filePath));
+    }
+    catch (e) {
+        console.error('Native print: failed to read PDF:', e.message);
+        res.status(500).json({ error: e.message });
+        return;
+    }
+    if (!pagePoints) {
+        const message = 'could not determine PDF page size (no MediaBox)';
+        console.error('Native print:', message, filePath);
+        res.status(500).json({ error: message });
+        return;
+    }
+    const renderDelay = 1500;
+    const options = Object.assign(Object.assign({}, buildNativePrintOptions(printer, pagePoints)), (settings && typeof settings === 'object' ? settings : {}));
+    let printWindow = new BrowserWindow({
+        show: false,
+        backgroundColor: '#ffffff',
+        webPreferences: {
+            plugins: true,
+        },
+    });
+    let responded = false;
+    const respond = (statusCode, error) => {
+        if (responded) {
+            return;
+        }
+        responded = true;
+        if (error) {
+            res.status(statusCode).json({ error });
+        }
+        else {
+            res.sendStatus(statusCode);
+        }
+        if (printWindow) {
+            printWindow.close();
+            printWindow = null;
+        }
+    };
+    printWindow.webContents.once('did-finish-load', () => {
+        setTimeout(() => {
+            if (!printWindow) {
+                return;
+            }
+            printWindow.webContents.print(options, (success, errorType) => {
+                if (success) {
+                    respond(200);
+                }
+                else {
+                    console.error('Native print job failed:', errorType);
+                    respond(500, errorType);
+                }
+            });
+        }, renderDelay);
+    });
+    printWindow.webContents.on('did-fail-load', (_event, _errorCode, errorDescription, _validatedURL, isMainFrame) => {
+        if (!isMainFrame) {
+            return;
+        }
+        console.error('Native print: failed to load PDF:', errorDescription);
+        respond(500, errorDescription);
+    });
+    printWindow.loadFile(filePath).catch((e) => {
+        respond(500, e.message);
+    });
 }));
 router.post('/print-to-pdf', (req, res) => __awaiter(void 0, void 0, void 0, function* () {
     const { html, settings } = req.body;

--- a/resources/electron/electron-plugin/src/server/api/system.ts
+++ b/resources/electron/electron-plugin/src/server/api/system.ts
@@ -1,5 +1,7 @@
 import { BrowserWindow, nativeTheme, safeStorage, systemPreferences } from 'electron';
 import express from 'express';
+import { readFileSync } from 'node:fs';
+import { parsePdfPageSizePoints, buildNativePrintOptions } from '../pdfPageSize.js';
 
 const router = express.Router();
 
@@ -93,6 +95,87 @@ router.post('/print', async (req, res) => {
     });
 
     await printWindow.loadURL(`data:text/html;charset=UTF-8,${html}`);
+});
+
+router.post('/print-file', async (req, res) => {
+    const { path: filePath, printer, settings } = req.body;
+
+    let pagePoints = null;
+    try {
+        pagePoints = parsePdfPageSizePoints(readFileSync(filePath));
+    } catch (e) {
+        console.error('Native print: failed to read PDF:', e.message);
+        res.status(500).json({ error: e.message });
+        return;
+    }
+
+    if (!pagePoints) {
+        const message = 'could not determine PDF page size (no MediaBox)';
+        console.error('Native print:', message, filePath);
+        res.status(500).json({ error: message });
+        return;
+    }
+
+    // Wait this long after load for PDFium to paint before printing
+    const renderDelay = 1500;
+
+    const options = {
+        ...buildNativePrintOptions(printer, pagePoints),
+        ...(settings && typeof settings === 'object' ? settings : {}),
+    };
+
+    let printWindow = new BrowserWindow({
+        show: false,
+        backgroundColor: '#ffffff',
+        webPreferences: {
+            plugins: true,
+        },
+    });
+
+    let responded = false;
+    const respond = (statusCode, error?) => {
+        if (responded) {
+            return;
+        }
+        responded = true;
+        if (error) {
+            res.status(statusCode).json({ error });
+        } else {
+            res.sendStatus(statusCode);
+        }
+        if (printWindow) {
+            printWindow.close();
+            printWindow = null;
+        }
+    };
+
+    printWindow.webContents.once('did-finish-load', () => {
+        setTimeout(() => {
+            if (!printWindow) {
+                return;
+            }
+            printWindow.webContents.print(options, (success, errorType) => {
+                if (success) {
+                    respond(200);
+                } else {
+                    console.error('Native print job failed:', errorType);
+                    respond(500, errorType);
+                }
+            });
+        }, renderDelay);
+    });
+
+    printWindow.webContents.on('did-fail-load', (_event, _errorCode, errorDescription, _validatedURL, isMainFrame) => {
+        if (!isMainFrame) {
+            return;
+        }
+        console.error('Native print: failed to load PDF:', errorDescription);
+        respond(500, errorDescription);
+    });
+
+    printWindow.loadFile(filePath).catch((e) => {
+        respond(500, e.message);
+    });
 });
 
 router.post('/print-to-pdf', async (req, res) => {

--- a/resources/electron/electron-plugin/src/server/pdfPageSize.ts
+++ b/resources/electron/electron-plugin/src/server/pdfPageSize.ts
@@ -1,0 +1,70 @@
+interface PagePoints {
+    widthPt: number;
+    heightPt: number;
+}
+
+interface PrintPageSize {
+    pageSize: { width: number; height: number };
+    landscape: boolean;
+}
+
+interface NativePrintOptions {
+    silent: true;
+    deviceName: string;
+    color: false;
+    landscape: boolean;
+    pageSize: { width: number; height: number };
+    margins: { marginType: 'custom'; top: 0; bottom: 0; left: 0; right: 0 };
+}
+
+const mediaBox = /\/MediaBox\s*\[\s*(-?[\d.]+)\s+(-?[\d.]+)\s+(-?[\d.]+)\s+(-?[\d.]+)\s*\]/;
+
+export function parsePdfPageSizePoints(buffer: Buffer): PagePoints | null {
+    // latin1 keeps byte offsets stable for the ASCII PDF structure tokens.
+    const match = buffer.toString('latin1').match(mediaBox);
+    if (!match) {
+        return null;
+    }
+
+    const x0 = parseFloat(match[1]);
+    const y0 = parseFloat(match[2]);
+    const x1 = parseFloat(match[3]);
+    const y1 = parseFloat(match[4]);
+
+    const widthPt = Math.abs(x1 - x0);
+    const heightPt = Math.abs(y1 - y0);
+
+    if (!(widthPt > 0) || !(heightPt > 0)) {
+        return null;
+    }
+
+    return { widthPt, heightPt };
+}
+
+// PDF points (1/72") to microns (Electron pageSize unit, 1/25400").
+function pointsToMicrons(points: number): number {
+    return Math.round((points / 72) * 25400);
+}
+
+function toPrintPageSize({ widthPt, heightPt }: PagePoints): PrintPageSize {
+    return {
+        pageSize: {
+            width: pointsToMicrons(widthPt),
+            height: pointsToMicrons(heightPt),
+        },
+        landscape: widthPt > heightPt,
+    };
+}
+
+export function buildNativePrintOptions(deviceName: string, page: PagePoints): NativePrintOptions {
+    const { pageSize, landscape } = toPrintPageSize(page);
+
+    return {
+        silent: true,
+        deviceName,
+        color: false,
+        landscape,
+        pageSize,
+        margins: { marginType: 'custom', top: 0, bottom: 0, left: 0, right: 0 },
+    };
+}

--- a/resources/electron/electron-plugin/tests/pdfPageSize.test.ts
+++ b/resources/electron/electron-plugin/tests/pdfPageSize.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { parsePdfPageSizePoints, buildNativePrintOptions } from '../src/server/pdfPageSize';
+
+// Minimal PDF text containing a 4x6 inch MediaBox (288 x 432 points).
+const pdf4x6 = Buffer.from(
+    '%PDF-1.4\n1 0 obj<</Type/Page/MediaBox [0 0 288 432]>>endobj\n%%EOF',
+    'latin1',
+);
+
+// 6x4 inch sample (432 x 288 points), width > height → landscape.
+const pdf6x4 = Buffer.from(
+    '%PDF-1.4\n1 0 obj<</Type/Page/MediaBox[0 0 432 288]>>endobj\n%%EOF',
+    'latin1',
+);
+
+describe('pdfPageSize', () => {
+    it('parses the first MediaBox into points', () => {
+        expect(parsePdfPageSizePoints(pdf4x6)).toEqual({ widthPt: 288, heightPt: 432 });
+    });
+
+    it('handles MediaBox with no spaces after the key and decimals', () => {
+        const pdf = Buffer.from('/MediaBox[0 0 283.5 425.25]', 'latin1');
+        expect(parsePdfPageSizePoints(pdf)).toEqual({ widthPt: 283.5, heightPt: 425.25 });
+    });
+
+    it('returns null when no MediaBox is present', () => {
+        expect(parsePdfPageSizePoints(Buffer.from('not a pdf', 'latin1'))).toBeNull();
+    });
+
+    it('returns null for a degenerate (zero-area) MediaBox', () => {
+        expect(parsePdfPageSizePoints(Buffer.from('/MediaBox [0 0 0 432]', 'latin1'))).toBeNull();
+    });
+
+    it('derives size from a non-zero origin MediaBox', () => {
+        // Origin offset must not change the page dimensions: 298-10 x 442-10.
+        expect(parsePdfPageSizePoints(Buffer.from('/MediaBox [10 10 298 442]', 'latin1')))
+            .toEqual({ widthPt: 288, heightPt: 432 });
+    });
+
+    it('handles negative coordinates via absolute size', () => {
+        expect(parsePdfPageSizePoints(Buffer.from('/MediaBox [-288 -432 0 0]', 'latin1')))
+            .toEqual({ widthPt: 288, heightPt: 432 });
+    });
+
+    it('uses the first MediaBox when several are present', () => {
+        const pdf = Buffer.from('/MediaBox [0 0 288 432] ... /MediaBox [0 0 595 842]', 'latin1');
+        expect(parsePdfPageSizePoints(pdf)).toEqual({ widthPt: 288, heightPt: 432 });
+    });
+
+    it('builds portrait print options with microns page size and zeroed margins', () => {
+        expect(buildNativePrintOptions('Test Printer', { widthPt: 288, heightPt: 432 })).toEqual({
+            silent: true,
+            deviceName: 'Test Printer',
+            color: false,
+            landscape: false,
+            pageSize: { width: 101600, height: 152400 }, // 4in x 6in in microns
+            margins: { marginType: 'custom', top: 0, bottom: 0, left: 0, right: 0 },
+        });
+    });
+
+    it('builds landscape print options for a wider-than-tall page (6x4)', () => {
+        const points = parsePdfPageSizePoints(pdf6x4);
+        expect(points).not.toBeNull();
+        expect(buildNativePrintOptions('Test Printer', points!)).toEqual({
+            silent: true,
+            deviceName: 'Test Printer',
+            color: false,
+            landscape: true,
+            pageSize: { width: 152400, height: 101600 }, // 6in x 4in in microns
+            margins: { marginType: 'custom', top: 0, bottom: 0, left: 0, right: 0 },
+        });
+    });
+
+    it('parses a MediaBox whose array spans multiple lines', () => {
+        const pdf = Buffer.from('/MediaBox [0 0\n288 432]', 'latin1');
+        expect(parsePdfPageSizePoints(pdf)).toEqual({ widthPt: 288, heightPt: 432 });
+    });
+});

--- a/src/Facades/System.php
+++ b/src/Facades/System.php
@@ -12,8 +12,9 @@ use Native\Desktop\Enums\SystemThemesEnum;
  * @method static string encrypt(string $string)
  * @method static string decrypt(string $string)
  * @method static array printers()
- * @method static void print(string $html, ?\Native\Desktop\DataObjects\Printer $printer = null)
- * @method static string printToPDF(string $reason)
+ * @method static void print(string $html, ?\Native\Desktop\DataObjects\Printer $printer = null, ?array $settings = [])
+ * @method static bool printFile(string $path, \Native\Desktop\DataObjects\Printer|string|null $printer = null, ?array $settings = [])
+ * @method static string printToPDF(string $html, ?array $settings = [])
  * @method static string timezone()
  * @method static SystemThemesEnum theme(?SystemThemesEnum $theme = null)
  */

--- a/src/System.php
+++ b/src/System.php
@@ -73,6 +73,18 @@ class System
     }
 
     /**
+     * Print an on-disk PDF natively via Chromium's PDF viewer.
+     */
+    public function printFile(string $path, Printer|string|null $printer = null, ?array $settings = []): bool
+    {
+        return $this->client->post('system/print-file', [
+            'path' => $path,
+            'printer' => $printer instanceof Printer ? $printer->name : ($printer ?? ''),
+            'settings' => $settings,
+        ])->successful();
+    }
+
+    /**
      * For $settings options, see https://www.electronjs.org/docs/latest/api/web-contents#contentsprinttopdfoptions
      */
     public function printToPDF(string $html, ?array $settings = []): string

--- a/tests/System/SystemPrintFileTest.php
+++ b/tests/System/SystemPrintFileTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Native\Desktop\DataObjects\Printer;
+use Native\Desktop\Facades\System;
+
+beforeEach(function () {
+    $this->pdfPath = sys_get_temp_dir().'/nativephp-print-test.pdf';
+    file_put_contents($this->pdfPath, '%PDF-1.4 test');
+});
+
+afterEach(function () {
+    @unlink($this->pdfPath);
+});
+
+it('sends a print-file request with path, printer and settings', function () {
+    Http::fake();
+
+    $printer = new Printer('Test Printer', 'Test Printer', 'Label printer', []);
+
+    $result = System::printFile($this->pdfPath, $printer, ['copies' => 2]);
+
+    expect($result)->toBeTrue();
+
+    Http::assertSent(function (Request $request) {
+        return $request->url() === 'http://localhost:4000/api/system/print-file'
+            && $request['path'] === $this->pdfPath
+            && $request['printer'] === 'Test Printer'
+            && $request['settings'] === ['copies' => 2];
+    });
+});
+
+it('defaults to an empty printer name and empty settings', function () {
+    Http::fake();
+
+    System::printFile($this->pdfPath);
+
+    Http::assertSent(function (Request $request) {
+        return $request->url() === 'http://localhost:4000/api/system/print-file'
+            && $request['path'] === $this->pdfPath
+            && $request['printer'] === ''
+            && $request['settings'] === [];
+    });
+});
+
+it('accepts a printer name string directly', function () {
+    Http::fake();
+
+    System::printFile($this->pdfPath, 'Test Printer');
+
+    Http::assertSent(function (Request $request) {
+        return $request['printer'] === 'Test Printer';
+    });
+});
+
+it('returns false when the print request fails', function () {
+    Http::fake([
+        '*/system/print-file' => Http::response(['error' => 'native print timed out waiting for the PDF to render'], 500),
+    ]);
+
+    expect(System::printFile($this->pdfPath))->toBeFalse();
+});


### PR DESCRIPTION
Add ability to print on Windows by adding a new `printFile` function, which is using Chromium's built-in PDF viewer.
Also solves https://github.com/NativePHP/desktop/issues/103.