### PR TITLE
Await PHP binary extraction before starting Electron

### DIFF
--- a/resources/electron/php.js
+++ b/resources/electron/php.js
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import fs_extra from 'fs-extra';
 import { join } from 'path';
+import { pipeline } from 'stream/promises';
 import unzip from 'yauzl';
 const { removeSync, ensureDirSync } = fs_extra;
 
@@ -63,35 +64,39 @@ if (platform.phpBinary) {
 
         ensureDirSync(binaryDestDir);
 
-        // Unzip the files
-        unzip.open(binarySrcDir, { lazyEntries: true }, function (err, zipfile) {
-            if (err) throw err;
-            zipfile.readEntry();
-            zipfile.on('entry', function (entry) {
-                zipfile.openReadStream(entry, function (err, readStream) {
-                    if (err) throw err;
+        await new Promise((resolve, reject) => {
+            unzip.open(binarySrcDir, { lazyEntries: true }, function (err, zipfile) {
+                if (err) {
+                    reject(err);
+                    return;
+                }
 
-                    const binaryPath = join(binaryDestDir, platform.phpBinary);
-                    const writeStream = fs.createWriteStream(binaryPath);
+                zipfile.on('error', reject);
+                zipfile.on('end', resolve);
+                zipfile.on('entry', function (entry) {
+                    zipfile.openReadStream(entry, function (err, readStream) {
+                        if (err) {
+                            reject(err);
+                            return;
+                        }
 
-                    readStream.pipe(writeStream);
+                        const binaryPath = join(binaryDestDir, platform.phpBinary);
+                        const writeStream = fs.createWriteStream(binaryPath);
 
-                    writeStream.on('close', function () {
-                        console.log('Copied PHP binary to ', binaryPath);
-
-                        // Add execute permissions
-                        fs.chmod(binaryPath, 0o755, (err) => {
-                            if (err) {
-                                console.log(`Error setting permissions: ${err}`);
-                            }
-                        });
-
-                        zipfile.readEntry();
+                        pipeline(readStream, writeStream)
+                            .then(() => fs.promises.chmod(binaryPath, 0o755))
+                            .then(() => {
+                                console.log('Copied PHP binary to ', binaryPath);
+                                zipfile.readEntry();
+                            })
+                            .catch(reject);
                     });
                 });
+                zipfile.readEntry();
             });
         });
     } catch (e) {
         console.error('Error copying PHP binary', e);
+        process.exitCode = 1;
     }
 }


### PR DESCRIPTION
## What changed

- wait for the bundled PHP archive to finish extracting before the Electron development process continues
- wait for executable permissions to be applied to the extracted PHP binary
- propagate extraction failures through a non-zero process exit code

## Why

`php.js` previously started the callback-based `yauzl` extraction and returned immediately. Because the package script chains it with `electron-vite dev`, Electron could start while the PHP binary was still being written or before `chmod` completed. On Linux this produced partial binaries, permission errors, and intermittent startup failures.

## Developer impact

NativePHP development startup now continues only after the bundled PHP executable is complete and runnable. Missing or unreadable archives also stop the package script instead of allowing startup to proceed with an invalid runtime.

## Validation

- `npx prettier --check php.js`
- `npx eslint php.js`
- `node --check php.js`
- extracted DevKeepr's real 65 MB Linux PHP 8.4 archive and executed `php --version` immediately after the script exited
- verified a missing archive returns exit code 1
