### PR TITLE
Add ability to toggle window fullscreen at runtime

### DIFF
--- a/resources/electron/electron-plugin/src/server/api/window.ts
+++ b/resources/electron/electron-plugin/src/server/api/window.ts
@@ -152,6 +152,14 @@ router.post('/always-on-top', (req, res) => {
     res.sendStatus(200);
 });
 
+router.post('/fullscreen', (req, res) => {
+    const { id, fullscreen } = req.body;
+
+    state.windows[id]?.setFullScreen(fullscreen);
+
+    res.sendStatus(200);
+});
+
 router.get('/current', (req, res) => {
     // Find the current window object
     const currentWindow = Object.values(state.windows).find(
@@ -359,6 +367,20 @@ router.post('/open', (req, res) => {
     window.on('unmaximize', () => {
         notifyLaravel('events', {
             event: 'Native\\Desktop\\Events\\Windows\\WindowUnmaximized',
+            payload: [id],
+        });
+    });
+
+    window.on('enter-full-screen', () => {
+        notifyLaravel('events', {
+            event: 'Native\\Desktop\\Events\\Windows\\WindowFullscreened',
+            payload: [id],
+        });
+    });
+
+    window.on('leave-full-screen', () => {
+        notifyLaravel('events', {
+            event: 'Native\\Desktop\\Events\\Windows\\WindowUnfullscreened',
             payload: [id],
         });
     });

--- a/src/Events/Windows/WindowFullscreened.php
+++ b/src/Events/Windows/WindowFullscreened.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Native\Desktop\Events\Windows;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class WindowFullscreened implements ShouldBroadcastNow
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(public string $id)
+    {
+        //
+    }
+
+    public function broadcastOn()
+    {
+        return [
+            new Channel('nativephp'),
+        ];
+    }
+}

--- a/src/Events/Windows/WindowUnfullscreened.php
+++ b/src/Events/Windows/WindowUnfullscreened.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Native\Desktop\Events\Windows;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class WindowUnfullscreened implements ShouldBroadcastNow
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(public string $id)
+    {
+        //
+    }
+
+    public function broadcastOn()
+    {
+        return [
+            new Channel('nativephp'),
+        ];
+    }
+}

--- a/src/Facades/Window.php
+++ b/src/Facades/Window.php
@@ -14,6 +14,7 @@ use Native\Desktop\Fakes\WindowManagerFake;
  * @method static void resize($width, $height, $id = null)
  * @method static void position($x, $y, $animated = false, $id = null)
  * @method static void alwaysOnTop($alwaysOnTop = true, $id = null)
+ * @method static void fullscreen($fullscreen = true, $id = null)
  * @method static void reload($id = null)
  * @method static void maximize($id = null)
  * @method static void unmaximize($id = null)

--- a/src/Windows/WindowManager.php
+++ b/src/Windows/WindowManager.php
@@ -97,6 +97,14 @@ class WindowManager implements WindowManagerContract
         ]);
     }
 
+    public function fullscreen($fullscreen = true, $id = null): void
+    {
+        $this->client->post('window/fullscreen', [
+            'id' => $id ?? $this->detectId(),
+            'fullscreen' => $fullscreen,
+        ]);
+    }
+
     public function maximize($id = null): void
     {
         $this->client->post('window/maximize', [

--- a/tests/Windows/WindowManagerTest.php
+++ b/tests/Windows/WindowManagerTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Native\Desktop\Facades\Window;
+
+it('can toggle a window into fullscreen', function () {
+    Http::fake();
+
+    Window::fullscreen(id: 'main');
+
+    Http::assertSent(function (Request $request) {
+        return $request->url() === 'http://localhost:4000/api/window/fullscreen'
+            && $request['id'] === 'main'
+            && $request['fullscreen'] === true;
+    });
+});
+
+it('can toggle a window out of fullscreen', function () {
+    Http::fake();
+
+    Window::fullscreen(fullscreen: false, id: 'main');
+
+    Http::assertSent(function (Request $request) {
+        return $request->url() === 'http://localhost:4000/api/window/fullscreen'
+            && $request['id'] === 'main'
+            && $request['fullscreen'] === false;
+    });
+});


### PR DESCRIPTION
Previously fullscreen could only be set when opening a window. 
Adds Window::fullscreen($fullscreen = true, $id = null), mirroring the existing alwaysOnTop() pattern, plus WindowFullscreened / WindowUnfullscreened broadcast events for the enter/leave-full-screen transitions.