### PR TITLE
Default the window zoom factor instead of passing NaN

### DIFF
--- a/resources/electron/electron-plugin/dist/server/api/window.js
+++ b/resources/electron/electron-plugin/dist/server/api/window.js
@@ -6,6 +6,11 @@ import { appendWindowIdToUrl, goToUrl, notifyLaravel } from '../utils.js';
 import mergePreferences from '../webPreferences.js';
 import { enable } from '@electron/remote/main/index.js';
 const router = express.Router();
+const DEFAULT_ZOOM_FACTOR = 1;
+function parseZoomFactor(zoomFactor) {
+    const zoom = parseFloat(zoomFactor);
+    return Number.isFinite(zoom) && zoom > 0 ? zoom : DEFAULT_ZOOM_FACTOR;
+}
 router.post('/maximize', (req, res) => {
     var _a;
     const { id } = req.body;
@@ -68,7 +73,7 @@ router.post('/hide-dev-tools', (req, res) => {
 router.post('/set-zoom-factor', (req, res) => {
     var _a;
     const { id, zoomFactor } = req.body;
-    (_a = state.windows[id]) === null || _a === void 0 ? void 0 : _a.webContents.setZoomFactor(parseFloat(zoomFactor));
+    (_a = state.windows[id]) === null || _a === void 0 ? void 0 : _a.webContents.setZoomFactor(parseZoomFactor(zoomFactor));
     res.sendStatus(200);
 });
 router.post('/position', (req, res) => {
@@ -267,7 +272,7 @@ router.post('/open', (req, res) => {
     const url = appendWindowIdToUrl(req.body.url, id);
     window.loadURL(url);
     window.webContents.on('dom-ready', () => {
-        window.webContents.setZoomFactor(parseFloat(zoomFactor));
+        window.webContents.setZoomFactor(parseZoomFactor(zoomFactor));
     });
     if (preventLeaveDomain || preventLeavePage) {
         window.webContents.on('will-navigate', (event, target) => {

--- a/resources/electron/electron-plugin/src/server/api/window.ts
+++ b/resources/electron/electron-plugin/src/server/api/window.ts
@@ -405,7 +405,9 @@ router.post('/open', (req, res) => {
     window.loadURL(url);
 
     window.webContents.on('dom-ready', () => {
-        window.webContents.setZoomFactor(parseFloat(zoomFactor));
+        const zoom = parseFloat(zoomFactor);
+
+        window.webContents.setZoomFactor(Number.isFinite(zoom) && zoom > 0 ? zoom : 1);
     });
 
     if (preventLeaveDomain || preventLeavePage) {

--- a/resources/electron/electron-plugin/src/server/api/window.ts
+++ b/resources/electron/electron-plugin/src/server/api/window.ts
@@ -9,6 +9,14 @@ import { enable } from '@electron/remote/main/index.js';
 
 const router = express.Router();
 
+const DEFAULT_ZOOM_FACTOR = 1;
+
+function parseZoomFactor(zoomFactor) {
+    const zoom = parseFloat(zoomFactor);
+
+    return Number.isFinite(zoom) && zoom > 0 ? zoom : DEFAULT_ZOOM_FACTOR;
+}
+
 router.post('/maximize', (req, res) => {
     const { id } = req.body;
 
@@ -92,7 +100,7 @@ router.post('/hide-dev-tools', (req, res) => {
 router.post('/set-zoom-factor', (req, res) => {
     const { id, zoomFactor } = req.body;
 
-    state.windows[id]?.webContents.setZoomFactor(parseFloat(zoomFactor));
+    state.windows[id]?.webContents.setZoomFactor(parseZoomFactor(zoomFactor));
 
     res.sendStatus(200);
 });
@@ -405,9 +413,7 @@ router.post('/open', (req, res) => {
     window.loadURL(url);
 
     window.webContents.on('dom-ready', () => {
-        const zoom = parseFloat(zoomFactor);
-
-        window.webContents.setZoomFactor(Number.isFinite(zoom) && zoom > 0 ? zoom : 1);
+        window.webContents.setZoomFactor(parseZoomFactor(zoomFactor));
     });
 
     if (preventLeaveDomain || preventLeavePage) {


### PR DESCRIPTION
`window/open` destructures `zoomFactor` from an optional payload and later does:

```ts
window.webContents.on('dom-ready', () => {
    window.webContents.setZoomFactor(parseFloat(zoomFactor));
});
```

When the key is absent that is `parseFloat(undefined)` → `NaN`, and `setZoomFactor(NaN)` does not no-op. The page renders at an extreme zoom. I hit this with a window showing about four enormous letters and no other symptom.

`Native\Desktop\Windows\Window` declares `protected float $zoomFactor = 1.0` and always serialises it, so the Laravel client never reaches this path. It only surfaces for a caller that omits the key, which the endpoint otherwise permits.

The fix falls back to `1` for anything non-finite or non-positive.
