### PR TITLE
Return 404 from window/current when no window is focused

### DIFF
--- a/resources/electron/electron-plugin/src/server/api/window.ts
+++ b/resources/electron/electron-plugin/src/server/api/window.ts
@@ -153,10 +153,15 @@ router.post('/always-on-top', (req, res) => {
 });
 
 router.get('/current', (req, res) => {
+    const focused = BrowserWindow.getFocusedWindow();
+
+    if (!focused) {
+        res.sendStatus(404);
+        return;
+    }
+
     // Find the current window object
-    const currentWindow = Object.values(state.windows).find(
-        (window) => window.id === BrowserWindow.getFocusedWindow().id,
-    );
+    const currentWindow = Object.values(state.windows).find((window) => window.id === focused.id);
 
     // Get the developer-assigned id for that window
     const id = Object.keys(state.windows).find((key) => state.windows[key] === currentWindow);


### PR DESCRIPTION
```ts
const currentWindow = Object.values(state.windows).find(
    (window) => window.id === BrowserWindow.getFocusedWindow().id,
);
```

`getFocusedWindow()` returns `null` when the app has no focused window — backgrounded, or all windows hidden — so `.id` throws. `getWindowData(undefined)` then throws a bare string rather than an `Error`, which is awkward to surface.

This is reachable from any PHP process that is not driving the UI. A queue worker or the scheduler calling `Window::current()` hits it whenever the user has the app in the background, so it fails intermittently and for reasons unrelated to the calling code.

404 seemed the closest fit to the existing convention — `window/get/:id` already answers 404 for a window that does not exist. Happy to return something else if you would rather distinguish "no focus" from "no such window".