### PR TITLE
Send a body with the 400 from shell/trash-item

### DIFF
--- a/resources/electron/electron-plugin/src/server/api/shell.ts
+++ b/resources/electron/electron-plugin/src/server/api/shell.ts
@@ -42,8 +42,10 @@ router.delete('/trash-item', async (req, res) => {
         await shell.trashItem(path);
 
         res.sendStatus(200);
-    } catch {
-        res.status(400).json();
+    } catch (e) {
+        res.status(400).json({
+            error: e instanceof Error ? e.message : String(e),
+        });
     }
 });
 


### PR DESCRIPTION
```ts
try {
    await shell.trashItem(path);
    res.sendStatus(200);
} catch {
    res.status(400).json();
}
```

`res.json()` with no argument throws in express, so the caught failure becomes an unhandled error inside the handler rather than the 400 the code intends. The caller sees a hung or 500 request instead of a clean failure.

Passing the message through also means the caller learns *why* — trashing fails for ordinary reasons (a permission problem, a path on a volume without a trash) and `PHP`-side `Shell::trash()` currently has no way to report which.