### PR TITLE
Report notifyLaravel failures under SHELL_VERBOSITY

### DIFF
--- a/resources/electron/electron-plugin/dist/server/utils.js
+++ b/resources/electron/electron-plugin/dist/server/utils.js
@@ -32,7 +32,10 @@ export function notifyLaravel(endpoint_1) {
                 },
             });
         }
-        catch (_a) {
+        catch (e) {
+            if (parseInt(process.env.SHELL_VERBOSITY) > 0) {
+                console.error(`notifyLaravel('${endpoint}') failed:`, e instanceof Error ? e.message : e);
+            }
         }
     });
 }

--- a/resources/electron/electron-plugin/src/server/utils.ts
+++ b/resources/electron/electron-plugin/src/server/utils.ts
@@ -23,8 +23,10 @@ export async function notifyLaravel(endpoint: string, payload = {}) {
                 'X-NativePHP-Secret': state.randomSecret,
             },
         });
-    } catch {
-        //
+    } catch (e) {
+        if (parseInt(process.env.SHELL_VERBOSITY) > 0) {
+            console.error(`notifyLaravel('${endpoint}') failed:`, e instanceof Error ? e.message : e);
+        }
     }
 }
 


### PR DESCRIPTION
```ts
export async function notifyLaravel(endpoint: string, payload = {}) {
    ...
    try {
        await axios.post(`http://127.0.0.1:${state.phpPort}/_native/api/${endpoint}`, payload, ...);
    } catch {
        //
    }
}
```

Every failure here is discarded, which makes these indistinguishable from a healthy app:

- the PHP server has died or has not finished booting
- a route returns 500
- `PreventRegularBrowserAccess` returns 403 because the secret does not match
- the app has no `/_native/api/events` route at all

In each case no event arrives, nothing appears in the Electron console, and the only symptom is a UI that quietly does not respond to native events.

This gates a `console.error` on `SHELL_VERBOSITY`, which `php.ts` already uses for its own command logging, so default runs stay as quiet as they are today.

I appreciate the empty `catch` is deliberate — the runtime should not fall over because the app is briefly unreachable, and that behaviour is unchanged here. Happy to move it behind `NODE_ENV === 'development'` instead, or to drop the gate entirely, whichever fits better.