### PR TITLE
Correct stale package metadata

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "desktop",
         "nativephp-laravel"
     ],
-    "homepage": "https://github.com/nativephp/laravel",
+    "homepage": "https://github.com/NativePHP/desktop",
     "license": "MIT",
     "funding": [
         {
@@ -110,7 +110,7 @@
                 "Shell": "Native\\Desktop\\Facades\\Shell",
                 "System": "Native\\Desktop\\Facades\\System",
                 "Window": "Native\\Desktop\\Facades\\Window",
-                "Updater": "Native\\Electron\\Facades\\Updater"
+                "Updater": "Native\\Desktop\\Drivers\\Electron\\Facades\\Updater"
             }
         }
     },


### PR DESCRIPTION
Two leftovers from the `nativephp/laravel` → `nativephp/desktop` merge:

**`homepage`** points at `https://github.com/nativephp/laravel`, which is archived.

**The `Updater` alias** points at `Native\Electron\Facades\Updater`:

```json
"aliases": {
    ...
    "Updater": "Native\\Electron\\Facades\\Updater"
}
```

but the class is at `Native\Desktop\Drivers\Electron\Facades\Updater` — `src/Drivers/Electron/Facades/Updater.php`. There is no `Native\Electron` namespace in the package, so `Updater::` currently resolves to a missing class.

Every other alias in that block is already `Native\Desktop\...`, so this looks like one that was missed rather than intentional.