### PR TITLE
Run pint in check mode for pull requests from forks

### DIFF
--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -1,6 +1,6 @@
 # Check and fix PHP code style issues
-# Pull request: automatically fix PHP code style issues
-# Main branch: only check PHP code style issues since we don't have write permission
+# Pull request from a branch in this repository: automatically fix PHP code style issues
+# Pull request from a fork, or a push: only check, since we cannot push to the fork or to main
 name: Check and fix PHP code style issues
 
 on:
@@ -23,21 +23,22 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.head_ref || github.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           fetch-depth: 0
 
       - name: Check PHP code style issues
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
         uses: aglipanci/laravel-pint-action@2.6
         with:
           verboseMode: true
           testMode: true
 
       - name: Fix PHP code style issues
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: aglipanci/laravel-pint-action@2.6
 
       - name: Commit changes
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: Fix styling


### PR DESCRIPTION
`php-code-styling` fails on every pull request that comes from a fork, including #127, #128 and #136. It is not a code style problem, the job dies before Pint even runs:

```
[command]/usr/bin/git branch --list --remote origin/fix/security-cookie-config-namespace
[command]/usr/bin/git tag --list fix/security-cookie-config-namespace
##[error]A branch or tag with the name 'fix/security-cookie-config-namespace' could not be found
```

Two things are going on.

1. The checkout passes `ref: github.head_ref` but no `repository:`, so it looks for the fork's branch inside this repository and cannot find it. `build-plugin.yml` already passes `repository: ${{ github.event.pull_request.head.repo.full_name }}`, this workflow was never given the same treatment.

2. Even with the checkout fixed, the auto fix path cannot work for a fork. `GITHUB_TOKEN` has no write access to the contributor's fork, so `git-auto-commit-action` gets a 403 and the job fails again with a confusing error instead of a code style report.

This change:

- adds `repository:` to the checkout, so the fork's branch is actually fetched
- runs Pint in `testMode` for fork pull requests, so the job reports real style problems and passes when there are none
- keeps the existing auto fix and commit behaviour for pull requests from branches in this repository

Behaviour for pushes and for internal branches is unchanged.
