### PR TITLE
Respect TTY availability when running the dev server

### DIFF
--- a/src/Drivers/Electron/Traits/ExecuteCommand.php
+++ b/src/Drivers/Electron/Traits/ExecuteCommand.php
@@ -5,6 +5,7 @@ namespace Native\Desktop\Drivers\Electron\Traits;
 use Illuminate\Support\Facades\Process;
 use Native\Desktop\Builder\Builder;
 use Native\Desktop\Drivers\Electron\ElectronServiceProvider;
+use Symfony\Component\Process\Process as SymfonyProcess;
 
 use function Laravel\Prompts\error;
 
@@ -40,7 +41,7 @@ trait ExecuteCommand
         $result = Process::path(ElectronServiceProvider::electronPath())
             ->env($envs[$type])
             ->forever()
-            ->tty(! $withoutInteraction && PHP_OS_FAMILY != 'Windows')
+            ->tty(! $withoutInteraction && SymfonyProcess::isTtySupported() && PHP_OS_FAMILY != 'Windows')
             ->run($command, function (string $type, string $output) {
                 if ($this->getOutput()->isVerbose()) {
                     echo $output;


### PR DESCRIPTION
Running `php artisan native:run` (or `native:serve`) outside an interactive terminal fails before the process starts:

```
Symfony\Component\Process\Exception\RuntimeException

  TTY mode requires /dev/tty to be read/writable.

  at vendor/symfony/process/Process.php:1087
```

`ExecuteCommand::executeCommand()` enables TTY mode whenever the caller has not explicitly asked for non-interactive mode, without checking whether a TTY is actually available:

```php
->tty(! $withoutInteraction && PHP_OS_FAMILY != 'Windows')
```

So the dev server cannot be started from CI, a scripted deploy, an editor task runner, or any background shell. `--no-interaction` does not help: it is threaded through to the dependency install, but the `dev` invocation still requests a TTY.

`BuildCommand` already guards against this ([`BuildCommand.php:183`](https://github.com/NativePHP/desktop/blob/main/src/Drivers/Electron/Commands/BuildCommand.php#L183)):

```php
->tty(SymfonyProcess::isTtySupported() && ! $this->option('no-interaction'))
```

This applies the same `isTtySupported()` check in `executeCommand()`, so both paths behave consistently. Where a TTY exists the behaviour is unchanged; where none exists the process now runs with piped output instead of throwing.

### Verifying

With this change, `php artisan native:run` starts normally in a non-interactive shell where it previously aborted at the TTY check. Without it, the same invocation needs a pseudo-terminal wrapper (`script -q /dev/null php artisan native:run`) as a workaround.

Pint and PHPStan pass on the changed file.