### PR TITLE
Let macOS apps with a non-ASCII APP_NAME launch

### DIFF
--- a/resources/electron/electron-builder.mjs
+++ b/resources/electron/electron-builder.mjs
@@ -13,6 +13,19 @@ const deepLinkProtocol = process.env.NATIVEPHP_DEEPLINK_SCHEME;
 const updaterEnabled = process.env.NATIVEPHP_UPDATER_ENABLED === 'true';
 const deleteAppDataOnUninstall = process.env.NATIVEPHP_NSIS_DELETE_APP_DATA === 'true';
 
+/*
+ * On macOS, electron-builder NFD-normalises every name it writes to disk - the .app bundle,
+ * the executable and each of the Electron helper apps - but it writes CFBundleName straight
+ * from the product name, which reaches us composed (NFC). Electron locates its helper apps
+ * by appending ' Helper (GPU).app' and friends to CFBundleName, so the two have to agree:
+ * for a name like 'MUNĖ' they don't, and the app traps on launch before it can spawn a
+ * single child process. Decomposing it ourselves puts CFBundleName in the same form as the
+ * names on disk. NFD leaves ASCII names untouched, so this is a no-op for everyone else.
+ *
+ * https://github.com/NativePHP/desktop/issues/98
+ */
+const macBundleName = appName ? appName.normalize('NFD') : undefined;
+
 // Azure signing configuration
 const azureEndpoint = process.env.NATIVEPHP_AZURE_ENDPOINT;
 const azureCertificateProfileName = process.env.NATIVEPHP_AZURE_CERTIFICATE_PROFILE_NAME;
@@ -108,6 +121,7 @@ export default {
         entitlementsInherit: 'build/entitlements.mac.plist',
         artifactName: appName + '-${version}-${arch}.${ext}',
         extendInfo: {
+            ...(macBundleName ? { CFBundleName: macBundleName, CFBundleDisplayName: macBundleName } : {}),
             NSCameraUsageDescription: "Application requests access to the device's camera.",
             NSMicrophoneUsageDescription: "Application requests access to the device's microphone.",
             NSDocumentsFolderUsageDescription: "Application requests access to the user's Documents folder.",

--- a/resources/electron/electron-plugin/tests/electronBuilder.test.ts
+++ b/resources/electron/electron-plugin/tests/electronBuilder.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// "MUNĖ" from https://github.com/NativePHP/desktop/issues/98, written out as escapes so the
+// two normalisation forms stay distinguishable however this file is stored.
+const composed = 'MUN\u0116'; // Ė as a single precomposed code point
+const decomposed = 'MUNE\u0307'; // E followed by a combining dot above
+
+async function loadBuilderConfig(appName: string) {
+    vi.resetModules();
+    vi.stubEnv('APP_PATH', '/fake/app/path');
+    vi.stubEnv('NATIVEPHP_BUILDING', '');
+    vi.stubEnv('NATIVEPHP_APP_NAME', appName);
+
+    return (await import('../../electron-builder.mjs')).default;
+}
+
+describe('electron-builder config', () => {
+    afterEach(() => {
+        vi.unstubAllEnvs();
+    });
+
+    it('decomposes the macOS bundle name so Electron can find its helper apps', async () => {
+        const config = await loadBuilderConfig(composed);
+
+        expect(config.mac.extendInfo.CFBundleName).toBe(decomposed);
+        expect(config.mac.extendInfo.CFBundleDisplayName).toBe(decomposed);
+    });
+
+    it('leaves the product name itself composed', async () => {
+        const config = await loadBuilderConfig(composed);
+
+        expect(config.productName).toBe(composed);
+    });
+
+    it('leaves ASCII app names untouched', async () => {
+        const config = await loadBuilderConfig('My App');
+
+        expect(config.mac.extendInfo.CFBundleName).toBe('My App');
+        expect(config.mac.extendInfo.CFBundleDisplayName).toBe('My App');
+    });
+
+    it('does not blank out the bundle name when no app name is set', async () => {
+        const config = await loadBuilderConfig('');
+
+        expect(config.mac.extendInfo).not.toHaveProperty('CFBundleName');
+        expect(config.mac.extendInfo).not.toHaveProperty('CFBundleDisplayName');
+    });
+
+    it('keeps the usage descriptions alongside the bundle name', async () => {
+        const config = await loadBuilderConfig(composed);
+
+        expect(config.mac.extendInfo.NSCameraUsageDescription).toBe(
+            "Application requests access to the device's camera.",
+        );
+    });
+});


### PR DESCRIPTION
Fixes #98.

Setting `APP_NAME` to something non-ASCII — the issue reports `MUNĖ` — builds fine but produces a macOS app that never opens a window and spawns no child processes at all.

## Root cause

Not quite what the issue guessed. `app-builder-lib`'s `MacPackager.prepareAppInfo()` constructs `AppInfo` with `normalizeNfd = true`, so every name electron-builder writes to disk is NFD-decomposed:

- the `.app` bundle and its executable, from `productFilename`
- every Electron helper app — `<name> Helper (GPU).app` and friends — which `electronMac.js` names from `sanitizedProductName`, with a comment noting that Electron resolves helpers via `CFBundleName`

But `applyCommonInfo()` writes `CFBundleName` and `CFBundleDisplayName` from the **raw** `appInfo.productName`, which arrives from the environment composed (NFC).

So the bundle gets `MUNĖ Helper (GPU).app` on disk while `CFBundleName` is `MUNĖ`. Electron can't line the two up and dies during startup, before it spawns anything. For ASCII names NFC and NFD are byte-identical, which is why this has gone unnoticed.

Worth noting the dead end, since it's the intuitive one: APFS is normalisation-*insensitive*, so `fs.existsSync()` on the NFC path does find the NFD directory. The failure isn't a filesystem lookup.

## Evidence

Reproduced with a bare Electron app on the versions we pin (electron 40, electron-builder 26):

| build | result |
| --- | --- |
| `productName: 'MUNE'` | launches, 3 helper children, window created |
| `productName: 'MUNĖ'` | exits 133 (SIGTRAP / `EXC_BREAKPOINT`) immediately, no children, no stderr |
| `MUNĖ` with `CFBundleName` rewritten to NFD | launches, 3 helper children, window created |
| `MUNĖ` re-signed, plist untouched (control) | still 133 — it's the name, not the ad-hoc signature |

The last row rules out code signing as the cause, and the third row is the fix, verified straight out of electron-builder with no post-processing.

## The change

`mac.extendInfo` now sets `CFBundleName` and `CFBundleDisplayName` to the NFD form of the app name. `extendInfo` is merged over the plist *after* `applyCommonInfo` writes it, so it wins.

- `productName` itself is left composed, so Windows and Linux are untouched.
- NFD is a no-op on ASCII, so nothing changes for any existing app.
- Guarded on truthiness: electron-builder strips `null`/`undefined` plist values, so an unset `NATIVEPHP_APP_NAME` would otherwise delete `CFBundleName` from the bundle entirely.

Five tests cover it; two of them fail with the fix backed out.

## Not addressed

Only macOS was investigated. On Linux `executableName` isn't set, so it defaults to the product name and a non-ASCII binary would land in `/opt` — untested, and no breakage reported there. Windows already sets `win.executableName` from the slugged filename.

This is arguably an electron-builder bug — it normalises the names on disk but not the plist key that indexes them — so an upstream issue may be worth filing alongside this workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLMT7W3hSqRwX9gpZM5pXr
