### PR TITLE
Pin extract-zip to a yauzl that can read the Electron archive

### DIFF
--- a/resources/electron/package-lock.json
+++ b/resources/electron/package-lock.json
@@ -5216,15 +5216,6 @@
                 "ieee754": "^1.1.13"
             }
         },
-        "node_modules/buffer-crc32": {
-            "version": "0.2.13",
-            "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-            "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-            "license": "MIT",
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/buffer-from": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -7490,13 +7481,15 @@
             }
         },
         "node_modules/extract-zip/node_modules/yauzl": {
-            "version": "2.10.0",
-            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-            "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+            "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
             "license": "MIT",
             "dependencies": {
-                "buffer-crc32": "~0.2.3",
-                "fd-slicer": "~1.1.0"
+                "pend": "~1.2.0"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/extsprintf": {
@@ -7601,15 +7594,6 @@
             "license": "ISC",
             "dependencies": {
                 "reusify": "^1.0.4"
-            }
-        },
-        "node_modules/fd-slicer": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-            "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-            "license": "MIT",
-            "dependencies": {
-                "pend": "~1.2.0"
             }
         },
         "node_modules/file-entry-cache": {

--- a/resources/electron/package.json
+++ b/resources/electron/package.json
@@ -104,6 +104,11 @@
         "vitest": "^4.1.8",
         "vitest-mock-commonjs": "^1.0.2"
     },
+    "overrides": {
+        "extract-zip": {
+            "yauzl": "^3.4.0"
+        }
+    },
     "exports": "./electron-plugin/dist/index.js",
     "imports": {
         "#plugin": "./electron-plugin/dist/index.js"


### PR DESCRIPTION
The separate PR you asked for in #150. This is the second half of #145: with `.npmrc` merged, Electron's postinstall now runs — but on a clean install the runtime still does not land.

## What happens

`extract-zip` resolves its own nested **yauzl 2.10.0**, which stalls partway through inflating a large deflated entry: it stops emitting data and never fires `end`, `error` or `close`. Electron's postinstall unzips the runtime with it, so extraction stops after the first entry and leaves:

```
node_modules/electron/dist/
└── LICENSES.chromium.html      # and nothing else
```

`install.js` still exits 0 and npm reports success, so nothing surfaces the problem until the app fails on a missing `Electron.app/Contents/Info.plist` — an error that names the wrong culprit.

The archive is not at fault: `unzip -t` reports all 585 entries intact on the same cached download.

## Why the existing dependency doesn't cover it

`resources/electron/package.json` already requires `yauzl: ^3.3.2`, but that does not reach `extract-zip`, which pins its own copy through `^2.10.0` — and Node resolves a nested copy in preference to the hoisted one. The override scopes the fix to the single place still on the broken release, leaving the top-level dependency untouched.

## Verified

`npm ci` in `resources/electron`, under a parent `.npmrc` containing `ignore-scripts=true` to match the Laravel 12 skeleton. Same command both times; only the override differs:

| | yauzl | files in `dist` | result |
| --- | --- | --- | --- |
| before | 2.10.0 | 1 | no binary |
| after | 3.4.0 | 261 | `Electron --version` → `v40.10.2` |

Both installs exit 0, which is why this is easy to miss.

## On the lockfile

Regenerated with `npm install --package-lock-only`. The diff is limited to the yauzl entry and the two transitive packages it no longer needs (`buffer-crc32`, `fd-slicer`) — nothing else re-resolved.